### PR TITLE
Change the gid of the docker group to match the host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,5 @@ RUN apt-get update && \
    apt-get clean && \
    usermod -aG docker jenkins
 
-# drop back to the regular jenkins user - good practice
-USER jenkins
+COPY entrypoint.sh /
+ENTRYPOINT /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,6 @@ RUN apt-get update && \
    usermod -aG docker jenkins
 
 COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
 ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN apt-get update && \
    usermod -aG docker jenkins
 
 COPY entrypoint.sh /
-ENTRYPOINT /entrypoint.sh
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This Dockerfile just takes the current, official Jenkins long term support (LTS)
 
 [It is recommended](https://github.com/jenkinsci/docker/blob/master/README.md) to create an explicit volume on the host machine, that will survive the container stop/restart/deletion. Use this argument when you run Docker: `-v jenkins_home:/var/jenkins_home`
 
-### Docker in Docker
+## Docker in Docker
 Its possible to run into some problems with Docker running inside another Docker container ([more info here](https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/)). A better approach is that a container does not run its own Docker daemon, but connects to the Docker daemon of the host system. That means, you will have a Docker CLI in the container, as well as on the host system, but they both connect to one and the same Docker daemon. At any time, there is only one Docker daemon running in your machine, the one running on the host system. This [article from Daniel Weibel](https://itnext.io/docker-in-docker-521958d34efd) really helped me understand this. To do this, you just bind mount to the host system daemon, using this argument when you run Docker: `-v /var/run/docker.sock:/var/run/docker.sock`
 
-### Running the container
+## Running the container
 The easiest way is to pull from Docker Hub:
 
     docker run -it -p 8080:8080 -p 50000:50000 \
@@ -33,3 +33,21 @@ Alternatively, you can clone this repository, build the image from the Dockerfil
 	    -v /var/run/docker.sock:/var/run/docker.sock \
 	    --restart unless-stopped \
 	    jenkins-docker
+
+## Adopting the group id of jenkins user
+
+Inside the container the user `jenkins` is running the main process.
+In order to access the file `/var/run/docker.sock` the user `jenkins` needs to be in the correct group.
+The group is dictated by the group id (gid) of the corresponding group on the host.
+
+The container allows to change the gid of the `docker` group inside the container to match the gid of the host.
+This is done by the environment variable `JENKINS_DOCKER_SOCKET_GID`.
+
+To set the gid to `900` as an example, you can adopt the code from above to
+
+    docker run -it -p 8080:8080 -p 50000:50000 \
+	    -v jenkins_home:/var/jenkins_home \
+	    -v /var/run/docker.sock:/var/run/docker.sock \
+	    -e JENKINS_DOCKER_SOCKET_GID=900
+	    --restart unless-stopped \
+	    4oh4/jenkins-docker

--- a/README.md
+++ b/README.md
@@ -34,20 +34,3 @@ Alternatively, you can clone this repository, build the image from the Dockerfil
 	    --restart unless-stopped \
 	    jenkins-docker
 
-## Adopting the group id of jenkins user
-
-Inside the container the user `jenkins` is running the main process.
-In order to access the file `/var/run/docker.sock` the user `jenkins` needs to be in the correct group.
-The group is dictated by the group id (gid) of the corresponding group on the host.
-
-The container allows to change the gid of the `docker` group inside the container to match the gid of the host.
-This is done by the environment variable `JENKINS_DOCKER_SOCKET_GID`.
-
-To set the gid to `900` as an example, you can adopt the code from above to
-
-    docker run -it -p 8080:8080 -p 50000:50000 \
-	    -v jenkins_home:/var/jenkins_home \
-	    -v /var/run/docker.sock:/var/run/docker.sock \
-	    -e JENKINS_DOCKER_SOCKET_GID=900
-	    --restart unless-stopped \
-	    4oh4/jenkins-docker

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,4 @@ if [ -n "$JENKINS_DOCKER_SOCKET_GID" ]; then
 	sed "s@^docker:x:999:@docker:x:$JENKINS_DOCKER_SOCKET_GID:@" -i /etc/group
 fi
 
-exec /sbin/tini -s -- su -c "PATH=$PATH /usr/local/bin/jenkins.sh $@" jenkins
+exec su -c "PATH=$PATH /usr/local/bin/jenkins.sh $@" jenkins

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,4 @@ if [ -n "$JENKINS_DOCKER_SOCKET_GID" ]; then
 	sed "s@^docker:x:999:@docker:x:$JENKINS_DOCKER_SOCKET_GID:@" -i /etc/group
 fi
 
-exec /sbin/tini -- su -c "PATH=$PATH /usr/local/bin/jenkins.sh $@" jenkins
+exec /sbin/tini -s -- su -c "PATH=$PATH /usr/local/bin/jenkins.sh $@" jenkins

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -n "$JENKINS_DOCKER_SOCKET_GID" ]; then
+	sed "s@^docker:x:999:@docker:x:$JENKINS_DOCKER_SOCKET_GID:@" -i /etc/group
+fi
+
+exec /sbin/tini -- su -c "PATH=$PATH /usr/local/bin/jenkins.sh $@" jenkins

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-if [ -n "$JENKINS_DOCKER_SOCKET_GID" ]; then
-	sed "s@^docker:x:999:@docker:x:$JENKINS_DOCKER_SOCKET_GID:@" -i /etc/group
-fi
+gid=$(stat --printf '%g' /var/run/docker.sock)
+sed "s@^docker:x:999:@docker:x:$gid:@" -i /etc/group
 
-exec su -c "PATH=$PATH /usr/local/bin/jenkins.sh $@" jenkins
+exec su jenkins -c "PATH=$PATH /usr/local/bin/jenkins.sh $@"


### PR DESCRIPTION
On the host the gid of the `docker` group is not always `999`. This PR allows to change the gid inside the docker image to something else on the fly.